### PR TITLE
Change variants values in flagd.json for use-new-counter-version feature

### DIFF
--- a/flagd/flagd.json
+++ b/flagd/flagd.json
@@ -3,10 +3,10 @@
     "flags": {
         "use-new-counter-version": {
             "state": "ENABLED",
-            "defaultVariant": "ENABLED",
+            "defaultVariant": "false",
             "variants": {
-                "ENABLED": true,
-                "DISABLED": false
+                "true": true,
+                "false": false
             },
             "targeting": {}
         },


### PR DESCRIPTION
Correct the values of `defaultVariant` and `variants` in the `flagd.json` configuration to ensure proper functionality of the `use-new-counter-version` feature.