### PR TITLE
Fix health check method to use HTTP in apiService and webfrontend projects

### DIFF
--- a/Todo.AppHost/Program.cs
+++ b/Todo.AppHost/Program.cs
@@ -16,14 +16,14 @@ var apiService = builder.AddProject<Projects.Todo_ApiService>("apiservice")
     .WithReference(redis)
     .WaitFor(redis)
     .WaitFor(flagd)
-    .WithHttpsHealthCheck("/health");
+    .WithHttpHealthCheck("/health");
 
 builder.AddProject<Projects.Todo_Web>("webfrontend")
     .WithExternalHttpEndpoints()
     .WithReference(redis)
     .WaitFor(redis)
     .WaitFor(flagd)
-    .WithHttpsHealthCheck("/health")
+    .WithHttpHealthCheck("/health")
     .WithReference(apiService)
     .WaitFor(apiService);
 


### PR DESCRIPTION
Update the health check method to use HTTP instead of HTTPS for improved compatibility in the apiService and webfrontend projects.