### PR TITLE
Update OpenTelemetry metrics meter name to "OpenFeature"

### DIFF
--- a/Todo.ServiceDefaults/Extensions.cs
+++ b/Todo.ServiceDefaults/Extensions.cs
@@ -73,7 +73,7 @@ public static class Extensions
             .WithMetrics(metrics =>
             {
                 metrics.AddAspNetCoreInstrumentation()
-                    .AddMeter("OpenFeature.Contrib.Hooks.Otel")
+                    .AddMeter("OpenFeature")
                     .AddHttpClientInstrumentation()
                     .AddRuntimeInstrumentation();
             })


### PR DESCRIPTION
This pull request includes a small change to the `ConfigureOpenTelemetry` method in `Todo.ServiceDefaults/Extensions.cs`. The change updates the meter name from `"OpenFeature.Contrib.Hooks.Otel"` to `"OpenFeature"` to align with the updated naming conventions.